### PR TITLE
Document version metadata sourcing

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ To work through the notebooks:
 2. Open one of the example notebooks in [`examples/`](examples/) and follow the embedded instructions. Each example demonstrates how to load data, preprocess it, and generate LEAF using utilities from [`src/`](src/), and export results.
 3. After the run completes, inspect the generated outputs in [`LEAFs/`](LEAFs/) to validate results or share them with your team.
 
+## Versioning
+The package version is managed from the single source declared in [`pyproject.toml`](pyproject.toml). The `sbtn_leaf`
+package exposes this value at runtime by reading the installed distribution metadata and, during local development,
+falling back to the `pyproject.toml` entry. Update the version in `pyproject.toml` when preparing a release to ensure
+that both the package metadata and the `sbtn_leaf.__version__` attribute report the same number.
+
 ## Contributing
 We welcome improvements to the data pipelines, documentation, examples, and new LEAFs. To contribute:
 1. Fork the repository and create a feature branch.

--- a/src/sbtn_leaf/__init__.py
+++ b/src/sbtn_leaf/__init__.py
@@ -31,5 +31,23 @@ Typical usage example:
 # ]
 
 # Package metadata
-__version__ = "version = 0.0.0.dev1"
+from importlib import metadata as _metadata
+from pathlib import Path
+
+
+try:
+    __version__ = _metadata.version("sbtn_leaf")
+except _metadata.PackageNotFoundError:
+    try:  # Python 3.11+
+        import tomllib
+    except ModuleNotFoundError:  # pragma: no cover - Python <3.11
+        tomllib = None
+
+    _pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    if tomllib is not None and _pyproject.exists():
+        with _pyproject.open("rb") as _fp:
+            __version__ = tomllib.load(_fp)["project"]["version"]
+    else:
+        __version__ = "0.0.0.dev1"
+
 __author__ = "Cristóbal Loyola"


### PR DESCRIPTION
## Summary
- load the `sbtn_leaf` package version from the installed distribution metadata with a `pyproject.toml` fallback when developing locally
- document how the package version is managed so contributors update `pyproject.toml`

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd61d46c408331ada4bf84eb36695c