### PR TITLE
Handle missing RothC inputs and add regression coverage

### DIFF
--- a/src/sbtn_leaf/RothC_Core.py
+++ b/src/sbtn_leaf/RothC_Core.py
@@ -408,10 +408,23 @@ def run_simulation(
     fym: Optional[np.ndarray] = None
 ) -> Tuple[np.ndarray, np.ndarray]:
     """Run RothC for n_years; return (soc_annual, co2_annual) arrays"""
+    tmp = np.asarray(tmp, dtype=float)
+    rain = np.asarray(rain, dtype=float)
+    evap = np.asarray(evap, dtype=float)
+    pc = np.asarray(pc, dtype=int)
+    if c_inp is None:
+        c_inp = np.zeros_like(tmp, dtype=float)
+    else:
+        c_inp = np.asarray(c_inp, dtype=float)
+    if fym is None:
+        fym = np.zeros_like(tmp, dtype=float)
+    else:
+        fym = np.asarray(fym, dtype=float)
+
     pools = initialize_pools(soc0, clay)
     pools.IOM = iom
     swc = 0.0
-    
+
     # optional spin-up
     if do_equilibrium:
         _, swc, _, _, _, _ = run_equilibrium(

--- a/tests/test_rothc_core.py
+++ b/tests/test_rothc_core.py
@@ -1,0 +1,26 @@
+import numpy as np
+
+from sbtn_leaf.RothC_Core import run_simulation
+
+
+def test_run_simulation_defaults_no_optional_inputs():
+    n_years = 1
+    months = n_years * 12
+    soc_annual, co2_annual = run_simulation(
+        clay=30.0,
+        depth=23.0,
+        iom=5.0,
+        soc0=50.0,
+        tmp=np.full(months, 10.0),
+        rain=np.full(months, 50.0),
+        evap=np.full(months, 20.0),
+        pc=np.zeros(months, dtype=int),
+        dpm_rpm=1.44,
+        n_years=n_years,
+        do_equilibrium=True,
+    )
+
+    assert soc_annual.shape == (n_years,)
+    assert co2_annual.shape == (n_years,)
+    assert np.isfinite(soc_annual).all()
+    assert np.isfinite(co2_annual).all()


### PR DESCRIPTION
## Summary
- default optional carbon input arrays in `run_simulation` to zero arrays derived from temperature inputs
- ensure the equilibrium spin-up path consumes the zeroed arrays instead of slicing `None`
- add a regression test covering calls to `run_simulation` without optional inputs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dda8781358833180bd7880eedb46c8