### PR TITLE
Fix TRM SOC handling and add regression tests

### DIFF
--- a/src/sbtn_leaf/RothC_Raster.py
+++ b/src/sbtn_leaf/RothC_Raster.py
@@ -315,6 +315,7 @@ def raster_rothc_annual_results_1yrloop(
     co2_annual[0] = 0
     
     dt = 1.0 / 12.0
+
     for t_abs in trange(months, desc="RothC months", position=1):
         # Re-assigning t_abs into t
         t = t_abs % 12
@@ -430,6 +431,8 @@ def raster_rothc_ReducedTillage_annual_results_1yrloop(
     co2_annual[0] = 0
     
     dt = 1.0 / 12.0
+    sand_has_time_dim = sand.ndim == 3
+
     for t_abs in trange(months, desc="RothC months", position=1):
         # Re-assigning t_abs into t
         t = t_abs % 12 
@@ -446,8 +449,12 @@ def raster_rothc_ReducedTillage_annual_results_1yrloop(
         rm_pc = RMF_PC(pc[t])
         rate_m = rm_tmp * rm_moist * rm_pc
 
-        # Tillage Rate Modifiers (TRMs)
-        TRM_DPM, TRM_RPM, TRM_BIO, TRM_HUM = RMF_TRM(sand[t], SOC[t])
+        # Tillage Rate Modifiers (TRMs). Sand inputs can be either time-varying
+        # (3-D) or static (2-D). In both cases RMF_TRM expects 2-D arrays that
+        # match the spatial SOC state, so we slice only when a time dimension is
+        # present and always pass the full SOC grid.
+        sand_current = sand[t] if sand_has_time_dim else sand
+        TRM_DPM, TRM_RPM, TRM_BIO, TRM_HUM = RMF_TRM(sand_current, SOC)
         
         # Decomposition
         D1 = DPM * np.exp(-rate_m * TRM_DPM * 10.0 * dt)
@@ -712,9 +719,9 @@ def run_rothC_sceneraios_from_csv(csv_filepath):
     for scenario in scenario_list:
     #for scenario in tqdm(scenario_list, desc="Running RothC Scenarios", unit="scenario", position=0):
         # tqdm.write(f"Processing scenario: {scenario['practices_string_id']}")
-        print(f"Running {scenario["crop_name"]} - {scenario["practices_string_id"]}")
+        print(f"Running {scenario['crop_name']} - {scenario['practices_string_id']}")
         run_RothC(**scenario)
-        print(f"\n\n")
+        print("\n\n")
 
 ##########################################
 #### OTHER USEFUL FUNCTIONS FOR ROTHC ####

--- a/tests/test_rothc_raster.py
+++ b/tests/test_rothc_raster.py
@@ -1,0 +1,93 @@
+import numpy as np
+
+from sbtn_leaf.RothC_Raster import (
+    raster_rothc_ReducedTillage_annual_results_1yrloop,
+)
+
+
+def test_reduced_tillage_trm_uses_full_soc(monkeypatch):
+    n_years = 1
+    y = x = 2
+    months = 12
+
+    clay = np.full((y, x), 30.0, dtype=float)
+    soc0 = np.full((y, x), 50.0, dtype=float)
+    tmp = np.full((months, y, x), 15.0, dtype=float)
+    rain = np.full((months, y, x), 80.0, dtype=float)
+    evap = np.full((months, y, x), 20.0, dtype=float)
+    pc = np.ones((months, y, x), dtype=int)
+    sand = np.full((y, x), 40.0, dtype=float)
+
+    call_counter = {"count": 0}
+
+    def fake_trm(sand_arr, soc_arr):
+        call_counter["count"] += 1
+        assert sand_arr.shape == (y, x)
+        assert soc_arr.shape == (y, x)
+        # return neutral modifiers so dynamics remain stable
+        ones = np.ones_like(sand_arr, dtype=float)
+        return ones, ones, ones, ones
+
+    monkeypatch.setattr(
+        "sbtn_leaf.RothC_Raster.RMF_TRM",
+        fake_trm,
+    )
+
+    soc_annual, co2_annual = raster_rothc_ReducedTillage_annual_results_1yrloop(
+        n_years=n_years,
+        clay=clay,
+        soc0=soc0,
+        tmp=tmp,
+        rain=rain,
+        evap=evap,
+        pc=pc,
+        sand=sand,
+    )
+
+    # TRM should be applied once per monthly timestep (n_years * 12)
+    assert call_counter["count"] == n_years * months
+
+    # Output shapes should remain consistent with expectations
+    assert soc_annual.shape == (n_years + 1, y, x)
+    assert co2_annual.shape == (n_years + 1, y, x)
+
+
+def test_reduced_tillage_trm_accepts_time_varying_sand(monkeypatch):
+    n_years = 1
+    y = x = 2
+    months = 12
+
+    clay = np.full((y, x), 30.0, dtype=float)
+    soc0 = np.full((y, x), 50.0, dtype=float)
+    tmp = np.full((months, y, x), 15.0, dtype=float)
+    rain = np.full((months, y, x), 80.0, dtype=float)
+    evap = np.full((months, y, x), 20.0, dtype=float)
+    pc = np.ones((months, y, x), dtype=int)
+    sand = np.full((months, y, x), 40.0, dtype=float)
+
+    captured_shapes = []
+
+    def fake_trm(sand_arr, soc_arr):
+        captured_shapes.append((sand_arr.shape, soc_arr.shape))
+        ones = np.ones_like(sand_arr, dtype=float)
+        return ones, ones, ones, ones
+
+    monkeypatch.setattr(
+        "sbtn_leaf.RothC_Raster.RMF_TRM",
+        fake_trm,
+    )
+
+    raster_rothc_ReducedTillage_annual_results_1yrloop(
+        n_years=n_years,
+        clay=clay,
+        soc0=soc0,
+        tmp=tmp,
+        rain=rain,
+        evap=evap,
+        pc=pc,
+        sand=sand,
+    )
+
+    # Every call should receive matching 2-D slices for sand and the full SOC state
+    assert len(captured_shapes) == n_years * months
+    assert all(s == ((y, x), (y, x)) for s in captured_shapes)


### PR DESCRIPTION
## Summary
- ensure reduced-tillage TRM uses the full SOC grid and handles static sand inputs
- correct CSV scenario logging string interpolation
- add regression tests validating TRM handling for static and time-varying sand arrays

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dda8bee98c8331a598f99784403a56