### PR TITLE
Fix PET annual key spelling and tighten tests

### DIFF
--- a/src/sbtn_leaf/PET.py
+++ b/src/sbtn_leaf/PET.py
@@ -461,7 +461,7 @@ def calculate_PET_crop_based(
     -------
     dict
         A dictionary with the following keys:
-        - 'PET_Annaul' : float
+        - 'PET_Annual' : float
             Total annual PET (mm/year) for the specified crop and location.
         - 'PET_Monthly' : pl.DataFrame
             Monthly PET values (mm/month), grouped by calendar month.
@@ -506,7 +506,7 @@ def calculate_PET_crop_based(
     PET_Annual = PET_Monthly['PET_Monthly'].sum()
 
     results = {
-        'PET_Annaul': PET_Annual,
+        'PET_Annual': PET_Annual,
         'PET_Monthly': PET_Monthly,
         'PET_Daily': PET_daily
     }

--- a/tests/test_pet.py
+++ b/tests/test_pet.py
@@ -142,6 +142,8 @@ def test_calculate_pet_crop_based_respects_leap_year_days():
         abs_date_table=abs_table,
     )
 
+    assert "PET_Annual" in results
+
     feb_total = (
         results["PET_Daily"]
         .filter(pl.col("Month") == 2)
@@ -152,3 +154,7 @@ def test_calculate_pet_crop_based_respects_leap_year_days():
     feb_monthly_input = calculate_PET_location_based(monthly_temps, 2024, 0.0)[1]
 
     assert feb_total == pytest.approx(feb_monthly_input, rel=1e-9)
+
+    monthly_total = results["PET_Monthly"].select(pl.col("PET_Monthly").sum()).item()
+
+    assert results["PET_Annual"] == pytest.approx(monthly_total, rel=1e-9)


### PR DESCRIPTION
## Summary
- rename the PET results dictionary key to the correctly spelled `PET_Annual`
- update documentation and tests to guard the expected key spelling

## Testing
- pytest tests/test_pet.py

------
https://chatgpt.com/codex/tasks/task_e_68dea0fc91148331be066fb7e6a259f3