### PR TITLE
Validate landuse raster alignment

### DIFF
--- a/src/sbtn_leaf/PET.py
+++ b/src/sbtn_leaf/PET.py
@@ -694,6 +694,12 @@ def calculate_crop_based_PET_raster_vPipeline(
             pet_base = pet_base.astype("float32", copy=False)
         thermal_zones = thermal_zone_raster.read(1).astype(int)          # (H, W)
         lu_data       = landuse_array.astype(int)          # (H, W)
+        expected_shape = (PET_raster.height, PET_raster.width)
+        if thermal_zones.shape != expected_shape or lu_data.shape != expected_shape:
+            raise ValueError(
+                "landuse_array and thermal_zones must match raster dimensions "
+                f"{expected_shape}; got landuse {lu_data.shape} and thermal {thermal_zones.shape}."
+            )
         profile       = PET_raster.profile.copy()
 
     H, W = pet_base.shape[1:]


### PR DESCRIPTION
## Summary
- add validation to ensure land-use masks align with the PET raster dimensions
- raise a descriptive error when raster shapes diverge
- cover the failure mode with a unit test that feeds a mismatched land-use array

## Testing
- pytest tests/test_pet.py::test_pipeline_pet_raises_on_landuse_shape_mismatch

------
https://chatgpt.com/codex/tasks/task_e_68dea779beec8331aa69374740d4d827