### PR TITLE
Update PET heat index aggregation

### DIFF
--- a/src/sbtn_leaf/PET.py
+++ b/src/sbtn_leaf/PET.py
@@ -182,7 +182,7 @@ def calculate_PET_location_based(monthly_temps, year: int, lat: float):
         raise ValueError("monthly_temps must contain exactly 12 values for each month.")
 
     # Step 1: Calculate I (heat index)
-    I = sum([(t / 5.0) ** 1.514 for t in monthly_temps if t > 0])
+    I = sum(calcualte_heat_index(temp) for temp in monthly_temps)
 
     # Step 2: Calculate exponent a
     a  = calcualte_a(I)

--- a/tests/test_pet.py
+++ b/tests/test_pet.py
@@ -26,6 +26,16 @@ def test_january_daylight_duration_does_not_raise_index_error():
     assert len(pet_values) == 12
 
 
+def test_negative_monthly_temperatures_return_zero_pet():
+    """Months with sub-zero temperatures should not contribute to PET totals."""
+
+    temps = [-5.0] * 12
+
+    pet_values = calculate_PET_location_based(temps, 2024, 45.0)
+
+    assert all(value == 0.0 for value in pet_values)
+
+
 def test_create_kc_curve_respects_stage_lengths_without_rollover():
     """The generated Kc curve should honour configured stage durations."""
 


### PR DESCRIPTION
## Summary
- sum monthly heat index contributions using the dedicated helper in PET calculations
- ensure negative temperature months produce zero PET and add regression coverage

## Testing
- pytest tests/test_pet.py

------
https://chatgpt.com/codex/tasks/task_e_68dea9c2f40c8331aaa7eeb409030170