### PR TITLE
Refactor TRM coefficient lookup in RMF_TRM

### DIFF
--- a/tests/test_rothc_core.py
+++ b/tests/test_rothc_core.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from sbtn_leaf.RothC_Core import run_simulation
+from sbtn_leaf.RothC_Core import RMF_TRM, run_simulation
 
 
 def test_run_simulation_defaults_no_optional_inputs():
@@ -24,3 +24,20 @@ def test_run_simulation_defaults_no_optional_inputs():
     assert co2_annual.shape == (n_years,)
     assert np.isfinite(soc_annual).all()
     assert np.isfinite(co2_annual).all()
+
+
+def test_rmf_trm_preserves_modifier_values():
+    sand = np.array([[10.0, 36.0], [38.0, 20.0]])
+    soc = np.array([[10.0, 80.0], [70.0, 100.0]])
+
+    trm_dpm, trm_rpm, trm_bio, trm_hum = RMF_TRM(sand, soc)
+
+    expected_dpm = np.array([[0.72, 1.54], [0.72, 0.72]])
+    expected_rpm = np.array([[0.97, 2.15], [0.97, 0.97]])
+    expected_bio = np.array([[0.99, 2.38], [0.99, 0.99]])
+    expected_hum = np.array([[0.94, 2.93], [0.94, 0.94]])
+
+    np.testing.assert_allclose(trm_dpm, expected_dpm)
+    np.testing.assert_allclose(trm_rpm, expected_rpm)
+    np.testing.assert_allclose(trm_bio, expected_bio)
+    np.testing.assert_allclose(trm_hum, expected_hum)


### PR DESCRIPTION
## Summary
- hoist the TRM coefficient tables to module scope for reuse
- refactor RMF_TRM to index into the constants with np.take instead of rebuilding arrays
- add a regression test covering representative sand/SOC combinations to ensure outputs are unchanged

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68deba13722883319fcc2a453ee5e484