### PR TITLE
Introduce lazy dataset loaders with error guards

### DIFF
--- a/src/sbtn_leaf/data_loader.py
+++ b/src/sbtn_leaf/data_loader.py
@@ -19,17 +19,31 @@ from pathlib import Path
 import calendar
 from typing import Dict, Iterable, Mapping, Tuple
 
+import geopandas as gpd
 import polars as pl
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DATA_DIR = REPO_ROOT / "data"
 
 
+def _ensure_exists(path: Path, *, description: str) -> Path:
+    """Ensure ``path`` exists before attempting to read it."""
+
+    if not path.exists():
+        raise FileNotFoundError(f"Expected {description} at '{path}'.")
+    return path
+
+
 @lru_cache(maxsize=None)
 def _load_crop_coefficients_table() -> pl.DataFrame:
     """Read the crop coefficient CSV from disk."""
 
-    return pl.read_csv(DATA_DIR / "crops" / "K_Crop_Data.csv")
+    path = _ensure_exists(
+        DATA_DIR / "crops" / "K_Crop_Data.csv",
+        description="crop coefficient lookup table",
+    )
+
+    return pl.read_csv(path)
 
 
 def get_crop_coefficients_table() -> pl.DataFrame:
@@ -42,7 +56,12 @@ def get_crop_coefficients_table() -> pl.DataFrame:
 def _load_absolute_day_table() -> pl.DataFrame:
     """Read the absolute day lookup table from disk."""
 
-    return pl.read_csv(DATA_DIR / "crops" / "AbsoluteDayTable.csv")
+    path = _ensure_exists(
+        DATA_DIR / "crops" / "AbsoluteDayTable.csv",
+        description="absolute day lookup table",
+    )
+
+    return pl.read_csv(path)
 
 
 def get_absolute_day_table() -> pl.DataFrame:
@@ -67,6 +86,132 @@ def get_days_in_month_table(year: int = 2023) -> pl.DataFrame:
     """Return a cached copy of the days-in-month table for ``year``."""
 
     return _build_days_in_month_table(year).clone()
+
+
+@lru_cache(maxsize=None)
+def _load_crop_naming_index_table() -> pl.DataFrame:
+    """Read the crop naming index CSV from disk."""
+
+    path = _ensure_exists(
+        DATA_DIR / "crops" / "crop_naming_index.csv",
+        description="crop naming index table",
+    )
+
+    return pl.read_csv(path)
+
+
+def get_crop_naming_index_table() -> pl.DataFrame:
+    """Return a cached copy of the crop naming index table."""
+
+    return _load_crop_naming_index_table().clone()
+
+
+@lru_cache(maxsize=None)
+def _load_fao_statistics_table() -> pl.DataFrame:
+    """Read the FAO production statistics CSV from disk."""
+
+    path = _ensure_exists(
+        DATA_DIR / "crops" / "Production_Crops_Livestock_E_All_Data.csv",
+        description="FAO production statistics table",
+    )
+
+    return pl.read_csv(path)
+
+
+def get_fao_statistics_table() -> pl.DataFrame:
+    """Return a cached copy of the FAO production statistics table."""
+
+    return _load_fao_statistics_table().clone()
+
+
+@lru_cache(maxsize=None)
+def _load_fao_crop_yields_table() -> pl.DataFrame:
+    """Read the FAO crop yields CSV from disk."""
+
+    path = _ensure_exists(
+        DATA_DIR / "crops" / "fao_crop_yields_1423.csv",
+        description="FAO crop yields table",
+    )
+
+    return pl.read_csv(path, separator=";")
+
+
+def get_fao_crop_yields_table() -> pl.DataFrame:
+    """Return a cached copy of the FAO crop yields table."""
+
+    return _load_fao_crop_yields_table().clone()
+
+
+@lru_cache(maxsize=None)
+def _load_country_boundaries() -> gpd.GeoDataFrame:
+    """Read the country boundary shapefile from disk."""
+
+    path = _ensure_exists(
+        DATA_DIR / "CountryLayers" / "Country_Level0" / "g2015_2014_0.shp",
+        description="country boundary shapefile",
+    )
+
+    return gpd.read_file(path)
+
+
+def get_country_boundaries() -> gpd.GeoDataFrame:
+    """Return a cached copy of the country boundary shapefile."""
+
+    return _load_country_boundaries().copy()
+
+
+@lru_cache(maxsize=None)
+def _load_ecoregions_shapefile() -> gpd.GeoDataFrame:
+    """Read the ecoregions shapefile from disk."""
+
+    path = _ensure_exists(
+        DATA_DIR / "Ecoregions2017" / "Ecoregions2017.shp",
+        description="ecoregions shapefile",
+    )
+
+    return gpd.read_file(path)
+
+
+def get_ecoregions_shapefile() -> gpd.GeoDataFrame:
+    """Return a cached copy of the ecoregions shapefile."""
+
+    return _load_ecoregions_shapefile().copy()
+
+
+@lru_cache(maxsize=None)
+def _load_crop_ag_residue_table() -> pl.DataFrame:
+    """Read the crop above-ground residue Excel sheet from disk."""
+
+    path = _ensure_exists(
+        DATA_DIR / "crops" / "crop_residue_data.xlsx",
+        description="crop residue workbook",
+    )
+
+    return pl.read_excel(path, sheet_name="crop_ABG_Res")
+
+
+def get_crop_ag_residue_table() -> pl.DataFrame:
+    """Return a cached copy of the crop above-ground residue table."""
+
+    return _load_crop_ag_residue_table().clone()
+
+
+@lru_cache(maxsize=None)
+def _load_crop_residue_ratio_table() -> pl.DataFrame:
+    """Read the crop residue ratio Excel sheet from disk."""
+
+    path = _ensure_exists(
+        DATA_DIR / "crops" / "crop_residue_data.xlsx",
+        description="crop residue workbook",
+    )
+
+    return pl.read_excel(path, sheet_name="crop_res_ratios")
+
+
+def get_crop_residue_ratio_table() -> pl.DataFrame:
+    """Return a cached copy of the crop residue ratio table."""
+
+    return _load_crop_residue_ratio_table().clone()
 
 
 THERMAL_CLIMATE_ROWS = [

--- a/tests/test_data_loader_lazy.py
+++ b/tests/test_data_loader_lazy.py
@@ -1,0 +1,36 @@
+import pytest
+
+from sbtn_leaf import data_loader
+
+
+@pytest.fixture(autouse=True)
+def clear_loader_caches():
+    """Ensure data loader caches are reset between tests."""
+
+    data_loader._load_crop_naming_index_table.cache_clear()
+    data_loader._load_fao_crop_yields_table.cache_clear()
+    data_loader._load_ecoregions_shapefile.cache_clear()
+
+    yield
+
+    data_loader._load_crop_naming_index_table.cache_clear()
+    data_loader._load_fao_crop_yields_table.cache_clear()
+    data_loader._load_ecoregions_shapefile.cache_clear()
+
+
+def test_crop_naming_index_missing_file(monkeypatch, tmp_path):
+    monkeypatch.setattr(data_loader, "DATA_DIR", tmp_path)
+    with pytest.raises(FileNotFoundError) as exc:
+        data_loader.get_crop_naming_index_table()
+    message = str(exc.value)
+    assert "crop naming index table" in message
+    assert str(tmp_path) in message
+
+
+def test_ecoregions_shapefile_missing(monkeypatch, tmp_path):
+    monkeypatch.setattr(data_loader, "DATA_DIR", tmp_path)
+    with pytest.raises(FileNotFoundError) as exc:
+        data_loader.get_ecoregions_shapefile()
+    message = str(exc.value)
+    assert "ecoregions shapefile" in message
+    assert str(tmp_path) in message


### PR DESCRIPTION
## Summary
- add cached loader utilities for the crop and climate datasets, including helpful missing-file errors
- refactor `cropcalcs` to consume the new loaders while exposing backward-compatible lazy proxies
- add regression tests covering the error handling when expected datasets are absent

## Testing
- pytest tests/test_data_loader_lazy.py
- pytest tests/test_import.py

------
https://chatgpt.com/codex/tasks/task_e_68debd48c8c88331b0a469e8065e0b3b