### PR TITLE
Honor explicit `min_val`/`max_val` for raster choropleths

### DIFF
--- a/src/sbtn_leaf/map_plotting.py
+++ b/src/sbtn_leaf/map_plotting.py
@@ -493,6 +493,8 @@ def plot_raster_on_world_extremes_cutoff(
     - When ``truncate_one_sided`` is ``True``, one-sided data uses the
       corresponding half of the colormap. When ``False`` (default), the full
       colormap is used while honoring divergence-centered normalization bounds.
+    - Explicit ``min_val``/``max_val`` bounds take precedence over divergence
+      centering when provided.
     """
 
     if base_shp is None:
@@ -519,8 +521,9 @@ def plot_raster_on_world_extremes_cutoff(
         elif divergence_center is None:
             resolved_divergence = None
 
-    vmin = vmax = None
-    if resolved_divergence is not None:
+    vmin = min_val
+    vmax = max_val
+    if (vmin is None) and (vmax is None) and (resolved_divergence is not None):
         valid = raster_data[np.isfinite(raster_data)]
         if valid.size:
             max_dev = np.max(np.abs(valid - resolved_divergence))
@@ -541,7 +544,7 @@ def plot_raster_on_world_extremes_cutoff(
         base_shp=base_shp,
         vmin=vmin,
         vmax=vmax,
-        divergence_center=divergence_center,
+        divergence_center=resolved_divergence,
         truncate_one_sided=truncate_one_sided,
         raster_crs=raster_crs,
         plt_show=plt_show


### PR DESCRIPTION
### Motivation

- Ensure explicit palette bounds provided via `min_val`/`max_val` drive the plotted colormap mapping so values below/above those bounds map to the colormap endpoints.
- Preserve existing divergence-centering behavior but only use symmetric `vmin`/`vmax` when no manual bounds are supplied.

### Description

- Set `vmin = min_val` and `vmax = max_val` in `plot_raster_on_world_extremes_cutoff` and only compute symmetric bounds around a divergence center when both `vmin` and `vmax` are `None` and a divergence center is provided.
- Pass the resolved divergence center into `_create_plt_choropleth` via the `divergence_center` parameter so the helper has the correct context for normalization.
- Document the precedence rule that explicit `min_val`/`max_val` bounds take precedence over divergence centering in the function docstring.
- Apply a trivial end-of-file newline normalization.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69792a2f26c88331ac3679a772a06da0)