### PR TITLE
Fix TRM node classification logic

### DIFF
--- a/src/sbtn_leaf/RothC_Core.py
+++ b/src/sbtn_leaf/RothC_Core.py
@@ -140,14 +140,14 @@ def RMF_TRM(sand, SOC):
     sand = np.asarray(sand, dtype=float)
     SOC = np.asarray(SOC, dtype=float)
 
-    # Classify each cell into one of the four decision-tree "nodes".  This
-    # retains the original step-by-step logic even though it results in only
-    # nodes 3 and 4 being reachable; the goal of the refactor is parity.
+    # Classify each cell into one of the four decision-tree nodes while
+    # preserving the high-SOC/high-sand branch split.
     SN1 = sand > 37.6
-    high_soc = (SOC > 75.7) & SN1
-    nodes = np.where(high_soc, 1, 2)
-    high_sand = (sand > 35.0) & (~SN1)
-    nodes = np.where(high_sand, 3, 4)
+    nodes = np.where(
+        SN1,
+        np.where(SOC > 75.7, 1, 2),
+        np.where(sand > 35.0, 3, 4),
+    )
     nodes_idx = nodes.astype(int) - 1
 
     # Look up the TRM coefficients for every pool simultaneously.

--- a/tests/test_rothc_core.py
+++ b/tests/test_rothc_core.py
@@ -2,7 +2,7 @@ import warnings
 
 import numpy as np
 
-from sbtn_leaf.RothC_Core import RMF_Tmp, _partition_to_bio_hum
+from sbtn_leaf.RothC_Core import RMF_Tmp, RMF_TRM, _partition_to_bio_hum
 
 
 def test_rmf_tmp_avoids_warnings_near_lower_bound():
@@ -70,3 +70,20 @@ def test_partition_to_bio_hum_scalar_and_array_consistency():
 
     np.testing.assert_allclose(array_scalar_bio[0], bio_scalar)
     np.testing.assert_allclose(array_scalar_hum[0], hum_scalar)
+
+
+def test_rmf_trm_selects_all_nodes():
+    sand = np.array([40.0, 40.0, 36.0, 30.0])
+    soc = np.array([80.0, 70.0, 50.0, 50.0])
+
+    trm_dpm, trm_rpm, trm_bio, trm_hum = RMF_TRM(sand, soc)
+
+    expected_dpm = np.array([1.54, 1.71, 1.54, 0.72])
+    expected_rpm = np.array([0.35, 0.35, 2.15, 0.97])
+    expected_bio = np.array([1.42, 0.38, 2.38, 0.99])
+    expected_hum = np.array([0.42, 0.87, 2.93, 0.94])
+
+    np.testing.assert_allclose(trm_dpm, expected_dpm)
+    np.testing.assert_allclose(trm_rpm, expected_rpm)
+    np.testing.assert_allclose(trm_bio, expected_bio)
+    np.testing.assert_allclose(trm_hum, expected_hum)


### PR DESCRIPTION
### Motivation
- Ensure `RMF_TRM` preserves the original high-SOC / high-sand branching so nodes assigned for TRM lookup are not overwritten during classification.

### Description
- Change node assignment in `src/sbtn_leaf/RothC_Core.py` to a nested `np.where` that first checks the `SN1` branch and then applies the `SOC` threshold or the lower-sand split, preserving the high-SOC/high-sand branch split.
- Add a unit test in `tests/test_rothc_core.py` that supplies representative `sand`/`SOC` arrays and asserts that all four TRM nodes are produced and that the selected TRM coefficients match the expected values.

### Testing
- Ran the test suite with `pytest -q`; the repository test run reported failures, however the failures are unrelated to the TRM change (pre-existing issues in other modules).
- The TRM-focused unit test (`tests/test_rothc_core.py`) was added to cover the four-node selection and validate coefficients.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979338573908331bbb54b3af2885dc7)