### PR TITLE
Refactor yield raster output helper

### DIFF
--- a/src/sbtn_leaf/cropcalcs.py
+++ b/src/sbtn_leaf/cropcalcs.py
@@ -653,13 +653,7 @@ def _create_crop_yield_raster_core(
 
     # Output block
     if config.write_output:
-        if output_rst_path is None:
-            raise ValueError("output_rst_path is required when write_output is True")
-        lu_meta.update(dtype="float32", count=1, nodata=np.nan)
-        with rasterio.open(output_rst_path, "w", **lu_meta) as dst:
-            dst.write(averaged_result[np.newaxis, ...])
-
-        print(f"Yield raster written to {output_rst_path}")
+        _write_yield_raster(output_rst_path, lu_meta, averaged_result)
 
     return CropYieldRasterResult(
         averaged_result=averaged_result,
@@ -675,6 +669,23 @@ def _create_crop_yield_raster_core(
         avg_wat_ratio=avg_wat_ratio,
         scaling_mode=scaling_mode,
     )
+
+
+def _write_yield_raster(
+    output_rst_path: Optional[str],
+    lu_meta: Dict[str, object],
+    averaged_result: np.ndarray,
+) -> None:
+    """Write the averaged yield raster to disk."""
+
+    if output_rst_path is None:
+        raise ValueError("output_rst_path is required when write_output is True")
+
+    lu_meta.update(dtype="float32", count=1, nodata=np.nan)
+    with rasterio.open(output_rst_path, "w", **lu_meta) as dst:
+        dst.write(averaged_result[np.newaxis, ...])
+
+    print(f"Yield raster written to {output_rst_path}")
 
 
 def create_crop_yield_raster(


### PR DESCRIPTION
### Motivation
- Extract raster file writing from the core computation so `_create_crop_yield_raster_core` always computes and returns `averaged_result` and file I/O/printing happen only when `write_output` is True.

### Description
- Add helper `_write_yield_raster(output_rst_path, lu_meta, averaged_result)` and replace the inline write/print block in `_create_crop_yield_raster_core` with a call to this helper; the helper validates `output_rst_path`, updates `lu_meta`, writes the raster with `rasterio`, and prints a confirmation.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983a81d79e483318f3e2b6d72e7b57b)