### PR TITLE
Vectorize ecoregion fill mapping in _fill_with_ecoregions

### DIFF
--- a/src/sbtn_leaf/cropcalcs.py
+++ b/src/sbtn_leaf/cropcalcs.py
@@ -536,17 +536,34 @@ def _fill_with_ecoregions(
 
     remaining = lu_mask & np.isnan(result)
     if np.any(remaining):
-        ys, xs = np.where(remaining)
-        for y, x in zip(ys, xs):
-            zid = int(zone_array[y, x])
-            if zid in ecoregion_avg:
-                result[y, x] = ecoregion_avg[zid]
-            else:
-                biome = biome_name_map.get(zid)
-                if isinstance(biome, str):
-                    result[y, x] = biome_avg.get(biome, global_fao_ratio)
-                else:
-                    result[y, x] = global_fao_ratio
+        zone_max = int(zone_array.max())
+        if zone_max >= 0:
+            zone_lookup = np.full(zone_max + 1, np.nan, dtype=float)
+            for zid, avg in ecoregion_avg.items():
+                if 0 <= zid <= zone_max:
+                    zone_lookup[zid] = avg
+
+            unique_zones = np.unique(zone_array)
+            unique_zones = unique_zones[unique_zones >= 0]
+            if unique_zones.size:
+                missing = np.isnan(zone_lookup[unique_zones])
+                if np.any(missing):
+                    for zid in unique_zones[missing]:
+                        biome = biome_name_map.get(int(zid))
+                        if isinstance(biome, str):
+                            zone_lookup[zid] = biome_avg.get(biome, global_fao_ratio)
+                        else:
+                            zone_lookup[zid] = global_fao_ratio
+            zone_lookup = np.where(np.isnan(zone_lookup), global_fao_ratio, zone_lookup)
+
+            remaining_zones = zone_array[remaining]
+            fill_vals = np.full(remaining_zones.shape, global_fao_ratio, dtype=float)
+            valid_zones = remaining_zones >= 0
+            if np.any(valid_zones):
+                fill_vals[valid_zones] = zone_lookup[remaining_zones[valid_zones]]
+            result[remaining] = fill_vals
+        else:
+            result[remaining] = global_fao_ratio
 
     remaining = lu_mask & np.isnan(result)
     if np.any(remaining):


### PR DESCRIPTION
### Motivation
- Remove the slow per-pixel Python loop in ` _fill_with_ecoregions` to improve performance when filling NaN yields from ecoregion/biome averages.
- Preserve the existing biome-level and global FAO fallback behavior and the `distance_transform_edt` fallback for any remaining NaNs.

### Description
- Replaced the `for y, x in zip(ys, xs)` per-pixel loop with a dense lookup array `zone_lookup` sized `zone_array.max()+1` and vectorized indexing to compute fill values. 
- Populate `zone_lookup` with `ecoregion_avg` values and fill missing zone entries by mapping zones to `biome_name_map` and `biome_avg`, using `global_fao_ratio` as a fallback. 
- Index `zone_array` for all remaining masked pixels at once to produce `fill_vals` and assign them into `result` in a single vectorized operation, with an edge-case branch that sets all fills to `global_fao_ratio` when no valid zones exist. 
- Kept the post-fill `distance_transform_edt` nearest-neighbor fallback to fill any NaNs that remain after the vectorized fill.

### Testing
- No automated tests were executed as part of this change.
- Basic static verification of the modified function was performed by committing the updated `src/sbtn_leaf/cropcalcs.py` file and inspecting the updated code paths.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983ac26ef588331966d97d52380adba)