### PR TITLE
Validate single-band land-use raster and add inline comments

### DIFF
--- a/src/sbtn_leaf/cropcalcs.py
+++ b/src/sbtn_leaf/cropcalcs.py
@@ -1979,7 +1979,23 @@ def prepare_crop_data_irrigation_plantcover(
     output_practice_based = output_base / f"{crop_name}_{crop_practice_string}"
 
     # Step 0 - Opening input path
-    lu_array = rxr.open_rasterio(lu_data_path, masked=False).squeeze()
+    # Load land-use raster so we can enforce single-band inputs before squeezing.
+    lu_raster = rxr.open_rasterio(lu_data_path, masked=False)
+    # Determine how many bands are present; default to 1 if the dimension is missing.
+    band_count = lu_raster.sizes.get("band", 1)
+    if band_count != 1:
+        raise ValueError(
+            f"Land-use raster '{lu_data_path}' has {band_count} bands; "
+            "multiband land-use rasters are not supported. Please provide a single-band raster."
+        )
+    # Explicitly select the first band to guarantee a 2D (H, W) array for downstream logic.
+    lu_array = lu_raster.isel(band=0).squeeze()
+    if lu_array.ndim != 2:
+        # Fail fast if the land-use raster still isn't 2D after band selection.
+        raise ValueError(
+            f"Land-use raster '{lu_data_path}' must be a 2D array shaped (H, W); "
+            f"got shape {lu_array.shape}."
+        )
 
     # Step 1 - Prepare PET and irrigation
     # Step 1.1 - PET


### PR DESCRIPTION
### Motivation
- Ensure the land-use raster passed to `prepare_crop_data_irrigation_plantcover` is a single-band 2D array so downstream functions receive the expected `(H, W)` shape and to fail fast with clear errors for unsupported multiband inputs.
- Make the raster loading and band-selection behavior explicit and easier to understand by adding inline comments around the change.

### Description
- Replace the previous one-liner `rxr.open_rasterio(...).squeeze()` with `lu_raster = rxr.open_rasterio(...); band_count = lu_raster.sizes.get("band", 1)` and raise a `ValueError` if `band_count != 1`.
- Explicitly select the first band using `lu_raster.isel(band=0).squeeze()` and validate `lu_array.ndim == 2`, raising a `ValueError` that includes the input path and actual shape when this check fails.
- Add inline comments explaining the single-band enforcement, the explicit first-band selection, and the fail-fast 2D shape validation.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984be0f1f808331ac4a4055ad91ac4f)