### PR TITLE
Add grid alignment checks and resampling in calculate_irrigation_vPipeline

### DIFF
--- a/src/sbtn_leaf/cropcalcs.py
+++ b/src/sbtn_leaf/cropcalcs.py
@@ -2292,6 +2292,21 @@ def calculate_irrigation_vPipeline(evap: np.ndarray, output_path: str, rain_fp =
         irr (np.array): Irrigation required (mm/month), where ET > precipitation; 0 elsewhere.
     """
 
+    def _get_rio_metadata(data: object) -> Tuple[Optional[CRS], Optional[Affine]]:
+        if not isinstance(data, xr.DataArray):
+            return None, None
+        try:
+            crs = data.rio.crs
+        except Exception:
+            return None, None
+        if crs is None:
+            return None, None
+        try:
+            transform = data.rio.transform()
+        except Exception:
+            transform = None
+        return crs, transform
+
     # Transform data into array if needed
     with rasterio.open(rain_fp) as src:
         rain = src.read().astype("float32")
@@ -2299,7 +2314,35 @@ def calculate_irrigation_vPipeline(evap: np.ndarray, output_path: str, rain_fp =
         rain_profile = src.profile
 
     rain = np.asarray(rain, dtype=float)
+
+    evap_crs, evap_transform = _get_rio_metadata(evap)
+    rain_transform = rain_profile.get("transform")
+    rain_da = None
+
+    shape_mismatch = np.asarray(evap).shape != rain.shape
+    grid_mismatch = (
+        evap_crs is not None
+        and rain_crs is not None
+        and (evap_crs != rain_crs or (evap_transform is not None and rain_transform is not None and evap_transform != rain_transform))
+    )
+
+    if shape_mismatch or grid_mismatch:
+        if evap_crs is None or evap_transform is None:
+            raise ValueError(
+                "Evapotranspiration inputs do not align with the rainfall grid. "
+                "Please provide evap inputs with matching shape and spatial alignment "
+                "(CRS/transform) or supply a georeferenced xarray DataArray so it can be resampled."
+            )
+        if rain_da is None:
+            rain_da = rxr.open_rasterio(rain_fp, masked=False)
+        evap = evap.rio.reproject_match(rain_da)
+
     evap = np.asarray(evap, dtype=float)
+    if evap.shape != rain.shape:
+        raise ValueError(
+            "Evapotranspiration inputs do not align with the rainfall grid after resampling. "
+            "Please provide aligned inputs with matching shape and spatial metadata."
+        )
 
     # Creates a new empty array
     irr = np.zeros_like(rain, dtype=float)


### PR DESCRIPTION
### Motivation
- Ensure evapotranspiration inputs align with the rainfall grid before computing irrigation so spatial mismatches don't produce incorrect results. 
- When possible, automatically resample georeferenced evap `xarray.DataArray` inputs to the rain grid to make the pipeline more robust. 
- Provide a clear, actionable error when inputs cannot be aligned so callers know how to fix their inputs.

### Description
- Add a helper `_get_rio_metadata` to extract `CRS` and `Affine` transform from an `xarray.DataArray` using `rioxarray` in `calculate_irrigation_vPipeline` in `src/sbtn_leaf/cropcalcs.py`.
- Detect shape mismatches and grid mismatches (CRS or transform differences) between `evap` and the rain raster read from `rain_fp` and branch accordingly.
- If `evap` is a georeferenced `xarray.DataArray`, resample it to match the rain grid with `evap.rio.reproject_match(rain_da)`; otherwise raise a descriptive `ValueError` instructing the caller to provide aligned inputs.
- Add a final shape check after any resampling and raise a descriptive error if alignment still fails.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984cdc53d7c8331b20ef89c765bce46)