### PR TITLE
Reset `file_fnw` per scenario to avoid stale state and UnboundLocalError

### DIFF
--- a/src/sbtn_leaf/RothC_Raster.py
+++ b/src/sbtn_leaf/RothC_Raster.py
@@ -1417,8 +1417,8 @@ def run_rothc_crops_scenarios_from_excel(excel_filepath: PathLike, all_new_files
 
     # 3) Iterate with tqdm
     for scenario in scenario_list:
-        if "force_new_file" in scenario:
-            file_fnw = scenario["force_new_file"]
+        file_fnw = None
+        file_fnw = scenario.get("force_new_file")
 
         if scenario["commodity_type"] == "permanent_crop":
             crop_type_string = "Permanent"


### PR DESCRIPTION
### Motivation
- Prevent a stale `file_fnw` value from carrying over between iterations and avoid an `UnboundLocalError` when the `force_new_file` column is missing in a scenario.

### Description
- At the top of the scenario loop set `file_fnw = None` and then assign `file_fnw = scenario.get("force_new_file")` so the later `elif` branch reads a local per-iteration value.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984d29a73fc8331a8329c0c49b27ea8)