### PR TITLE
Align crop scenario description selection with run_RothC_crops output naming

### DIFF
--- a/src/sbtn_leaf/RothC_Raster.py
+++ b/src/sbtn_leaf/RothC_Raster.py
@@ -1425,7 +1425,10 @@ def run_rothc_crops_scenarios_from_excel(excel_filepath: PathLike, all_new_files
         else:
             crop_type_string = "Annual"
         
-        scenario_description = (scenario["practices_string_id"] if "practices_string_id" in scenario else scenario    ["irr_yield_scaling"])
+        if scenario.get("commodity_type") == "permanent_crop":
+            scenario_description = scenario.get("irr_yield_scaling")
+        else:
+            scenario_description = scenario.get("practices_string_id")
         scn_string_text = f"{crop_type_string} crop - {scenario['crop_name']} - {scenario_description}"
 
         if run_test:


### PR DESCRIPTION
### Motivation
- Make the scenario description used for logging and output-path checks in `run_rothc_crops_scenarios_from_excel` follow the same logic as `run_RothC_crops` so the file-exists check matches actual outputs. 
- Avoid key lookup errors and ensure the description key is chosen according to `commodity_type` (permanent vs annual).

### Description
- Update `src/sbtn_leaf/RothC_Raster.py` to select `scenario_description` with an explicit `commodity_type` check: use `irr_yield_scaling` for `permanent_crop` and `practices_string_id` for others. 
- Use `scenario.get(...)` for safe key access to avoid raising `KeyError` when the field is missing. 
- Keep the constructed `output_string` format unchanged so it aligns with `result_basename` built in `run_RothC_crops`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984d52596c88331b9a7da44bc1a408f)