### PR TITLE
Preserve and document nodata fallbacks during reprojection and masking

### DIFF
--- a/src/sbtn_leaf/map_calculations.py
+++ b/src/sbtn_leaf/map_calculations.py
@@ -621,9 +621,29 @@ def calculate_area_weighted_cfs_from_raster_with_std_and_median_vOutliers(
 
     # Ensure equal-area CRS
     # If raster isn't in equal-area, reproject raster to equal_area_crs
+    def _resolve_nodata(data_array: xr.DataArray) -> Optional[float]:
+        # Prefer the explicit rio nodata tag when available.
+        nodata_value = data_array.rio.nodata
+        if nodata_value is None:
+            # Fall back to common CF/NetCDF-style attrs if rio nodata is unset.
+            for attr_key in ("_FillValue", "nodata"):
+                if attr_key in data_array.attrs and data_array.attrs[attr_key] is not None:
+                    nodata_value = data_array.attrs[attr_key]
+                    break
+        if nodata_value is None:
+            # As a last resort, use encoded nodata to catch per-band fill values.
+            nodata_value = data_array.rio.encoded_nodata()
+        return nodata_value
+
     need_reproj = raster_crs.is_geographic or (str(raster_crs) != equal_area_crs)
     if need_reproj:
-        raster = raster.rio.reproject(equal_area_crs, resampling=resampling)
+        # Carry forward the resolved nodata so reprojection preserves fill values.
+        reproject_nodata = _resolve_nodata(raster)
+        raster = raster.rio.reproject(
+            equal_area_crs,
+            resampling=resampling,
+            nodata=reproject_nodata,
+        )
         raster_crs = raster.rio.crs
 
     # Pre-compute the transform and pixel area once so it can be reused per region
@@ -674,11 +694,12 @@ def calculate_area_weighted_cfs_from_raster_with_std_and_median_vOutliers(
 
             # Extract band given as ndarray; masked is xarray.DataArray with shape (band, y, x)
             arr = masked.values[raster_band-1]  # (H, W)
-            # nodata from reprojected raster
-            nodata = masked.rio.nodata
+            # nodata from masked raster (with fallback to attrs/encoded values)
+            nodata = _resolve_nodata(masked)
 
             # Build validity mask for data values (finite and not nodata)
             if nodata is not None:
+                # Exclude fill/nodata values from stats to avoid contaminating averages.
                 valid = np.isfinite(arr) & (arr != nodata)
             else:
                 valid = np.isfinite(arr)


### PR DESCRIPTION
### Motivation
- Ensure fill/nodata pixels are reliably detected and excluded from area-weighted fractional cover stats after reprojection and clipping.
- Make the nodata resolution and masking intent explicit in the code via short inline comments so future readers understand the fallback order and why `nodata` is propagated.

### Description
- Add concise inline comments to the `_resolve_nodata` helper explaining the preference order: `data_array.rio.nodata`, then `attrs["_FillValue"|"nodata"]`, and finally `data_array.rio.encoded_nodata()`.
- Pass the resolved nodata into `raster.rio.reproject(..., nodata=...)` so the reprojected raster carries an explicit fill value.
- Use the same `_resolve_nodata` result for clipped/masked rasters and document that fill values are excluded when building the `valid` mask used for statistics.
- Minor logging/comment clarifications around masking and early skips when no valid data is present.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984db3474d88331b65e7bf56bfc42c9)