### PR TITLE
Guard against degenerate weight sums in CF stats

### DIFF
--- a/src/sbtn_leaf/map_calculations.py
+++ b/src/sbtn_leaf/map_calculations.py
@@ -744,6 +744,10 @@ def calculate_area_weighted_cfs_from_raster_with_std_and_median_vOutliers(
 
             # Weighted stats (population variance)
             wsum = np.sum(weights)
+            if (not np.isfinite(wsum)) or (wsum <= 0):
+                if log:
+                    log.debug("Degenerate weights for %s. Skipping...", region_text)
+                continue
             wmean = np.sum(values * weights) / wsum
             wvar = np.sum(weights * (values - wmean) ** 2) / wsum
             wstd = np.sqrt(wvar)


### PR DESCRIPTION
### Motivation
- Avoid divide-by-zero and NaN propagation when area weights are degenerate (zero or non-finite) by validating `wsum` before computing weighted statistics.

### Description
- In `src/sbtn_leaf/map_calculations.py`, inside `calculate_area_weighted_cfs_from_raster_with_std_and_median_vOutliers` added a check after `wsum = np.sum(weights)` that verifies `wsum` is finite and `> 0`, and if not logs a debug message and `continue`s to skip the region.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984dda1f7b08331964a19eb7df9b2ca)