### PR TITLE
Guard log1p outlier filtering from invalid negatives

### DIFF
--- a/src/sbtn_leaf/map_calculations.py
+++ b/src/sbtn_leaf/map_calculations.py
@@ -1194,6 +1194,12 @@ def _apply_outlier_filter(values, weights, method=None, q_low=0.01, q_high=0.99,
         keep = np.abs(val - avg) <= std_thresh * sd
 
     elif method in ['log1p_cap','log1p_win']:
+        valid_mask = val > -1
+        if not np.all(valid_mask):
+            val = val[valid_mask]
+            wghts = wghts[valid_mask]
+            if val.size == 0:
+                return val, wghts
         val_trans = np.log1p(val)
         mu = np.average(val_trans, weights=wghts)
         var = np.average((val_trans - mu) ** 2, weights=wghts)


### PR DESCRIPTION
### Motivation
- Prevent values <= -1 from producing invalid/non-finite results when applying `np.log1p` so downstream weighted averages remain valid.

### Description
- In `_apply_outlier_filter`, under the `log1p_cap`/`log1p_win` branch, drop entries where `val <= -1` and align `weights` (`wghts`) with the filtered `val`, and short-circuit with an early return if no valid values remain.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984dda33eb883318c682c7c8d4ab6a9)