### PR TITLE
Forward spam outlier options to yield calculation

### DIFF
--- a/src/sbtn_leaf/cropcalcs.py
+++ b/src/sbtn_leaf/cropcalcs.py
@@ -2074,7 +2074,10 @@ def calculate_monthly_residues_array(
         irr_fp=spam_irr_fp,
         rf_fp=spam_rf_fp,
         random_runs=random_runs,
-        print_outputs= print_outputs
+        print_outputs= print_outputs,
+        spam_outlier_strategy=spam_outlier_strategy,
+        spam_outlier_percentile=spam_outlier_percentile,
+        spam_outlier_k=spam_outlier_k,
     )
 
     # Step 4 - Create plant residue raster


### PR DESCRIPTION
### Motivation
- Ensure spam outlier configuration from `calculate_monthly_residues_array` is honored by forwarding options into `calculate_crop_yield_array_with_irrigation_scaling`.

### Description
- Updated `calculate_monthly_residues_array` to pass `spam_outlier_strategy`, `spam_outlier_percentile`, and `spam_outlier_k` as keyword arguments into the `calculate_crop_yield_array_with_irrigation_scaling` call.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984f282becc833195d328e0458339c6)