### PR TITLE
Pass spam outlier controls through irrigation-scaling yield raster wrapper

### DIFF
--- a/src/sbtn_leaf/cropcalcs.py
+++ b/src/sbtn_leaf/cropcalcs.py
@@ -2594,6 +2594,9 @@ def create_crop_yield_raster_with_irrigation_scaling_pipeline(
         apply_ecoregion_fill=apply_ecoregion_fill,
         random_runs=random_runs,
         print_outputs=print_outputs,
+        spam_outlier_strategy=spam_outlier_strategy,
+        spam_outlier_percentile=spam_outlier_percentile,
+        spam_outlier_k=spam_outlier_k,
     )
     return _create_crop_yield_raster_core(
         croplu_grid_raster,


### PR DESCRIPTION
### Motivation
- Ensure the `create_crop_yield_raster_with_irrigation_scaling_pipeline` wrapper forwards SPAM outlier control parameters so it honors the same outlier behavior as `calculate_crop_yield_array_with_irrigation_scaling`.

### Description
- Updated `create_crop_yield_raster_with_irrigation_scaling_pipeline` in `src/sbtn_leaf/cropcalcs.py` to pass `spam_outlier_strategy`, `spam_outlier_percentile`, and `spam_outlier_k` into `CropYieldRasterConfig(...)`.
- Confirmed that `calculate_crop_yield_array_with_irrigation_scaling` already forwards the same three outlier-control parameters, providing parity between the two wrappers.

### Testing
- Ran a quick grep to locate the wrappers with `rg -n "create_crop_yield_raster_with_irrigation_scaling_pipeline|calculate_crop_yield_array_with_irrigation_scaling|CropYieldRasterConfig\(" src/sbtn_leaf/cropcalcs.py`, which showed the updated constructor locations and succeeded.
- Ran a syntax check with `python -m py_compile src/sbtn_leaf/cropcalcs.py`, which failed due to a pre-existing `IndentationError` at line 917 unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cf0b562c48331bee6141a8c880d79)