### PR TITLE
Ensure FAO pre-filter lookup uses zone_id-mapped means

### DIFF
--- a/src/sbtn_leaf/cropcalcs.py
+++ b/src/sbtn_leaf/cropcalcs.py
@@ -635,6 +635,7 @@ def _pre_filter_yields_rasters(
 ):
     #  Initialize out
     out_arrays = [np.full_like(a, np.nan, dtype="float32") for a in spam_arrays]
+    zone_mean = dict(zip(fao_gdf["zone_id"], fao_gdf[fao_avg_yield_name]))
 
     # Pre-compute per-zone bounding boxes so local filters only process relevant windows.
     zone_bboxes: dict[int, tuple[int, int, int, int]] = {}
@@ -658,7 +659,7 @@ def _pre_filter_yields_rasters(
         r0, r1, c0, c1 = zone_bboxes[zid]
         zone_sub = zone_array[r0:r1, c0:c1]
         zid_mask = zone_sub == zid                      #  Mask of the country
-        fao_yield_zone_avg = row[fao_avg_yield_name]    #  Country yield average (10-year)
+        fao_yield_zone_avg = zone_mean[zid]             #  Country yield average (10-year)
 
         # For each array:
         for i, array in enumerate(spam_arrays):


### PR DESCRIPTION
### Motivation
- Ensure each FAO zone (`zone_id`) resolves its own FAO average yield reliably in `_pre_filter_yields_rasters` by key lookup rather than using the iterated `row[...]` access which can be error-prone.

### Description
- Build `zone_mean = dict(zip(fao_gdf["zone_id"], fao_gdf[fao_avg_yield_name]))` and use `fao_yield_zone_avg = zone_mean[zid]` inside `_pre_filter_yields_rasters` so each `zid` fetches its own FAO mean by key.

### Testing
- Ran `pytest -q tests/test_cropcalcs_yield.py` which failed (2 failed) due to a `KeyError: "Missing 'sd_yield' in FAO shapefile"` in the test setup that appears unrelated to this change.
- Performed a one-off Python validation with a synthetic `fao_gdf` (including an Indonesia example) to confirm `zone_mean[zid]` returns expected values, and that check passed.
- No temporary prints or assertions were left in the codebase after validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e2782ce3c8331838f5179bdf74e36)