### PR TITLE
Apply uncertainty month-by-month to 3D residue inputs and preserve sparse zero months

### DIFF
--- a/src/sbtn_leaf/RothC_Raster.py
+++ b/src/sbtn_leaf/RothC_Raster.py
@@ -641,13 +641,13 @@ def _raster_rothc_annual_results(
                     c_inp = np.zeros_like(rain)
                 else:
                     print(f"        Calculating residue inputs for {crop_type} {crop_name}")
-                    c_inp = cropcalcs._apply_uncertainty_to_yields(
-                        result = c_inp,
-                        fao_avg_yields_array = yields_results.fao_avg_yields_array_nonscaled,
-                        fao_sd_yields_array = yields_results.fao_sd_yields_array,
-                        lu_mask =yields_results.lu_mask,
-                        random_runs = residue_runs,
-                        )
+                    c_inp = cropcalcs._apply_uncertainty_to_monthly_residues(
+                        monthly_residues=c_inp,
+                        fao_avg_yields_array=yields_results.fao_avg_yields_array_nonscaled,
+                        fao_sd_yields_array=yields_results.fao_sd_yields_array,
+                        lu_mask=yields_results.lu_mask,
+                        random_runs=residue_runs,
+                    )
                     
                     # c_inp = cropcalcs.calculate_monthly_residues_array(
                     #    lu_fp=commodity_lu_fp,

--- a/src/sbtn_leaf/cropcalcs.py
+++ b/src/sbtn_leaf/cropcalcs.py
@@ -364,6 +364,49 @@ def _apply_uncertainty_to_yields(
     return averaged.astype("float32", copy=False)
 
 
+def _apply_uncertainty_to_monthly_residues(
+    monthly_residues: np.ndarray,
+    fao_avg_yields_array: np.ndarray,
+    fao_sd_yields_array: np.ndarray,
+    lu_mask: np.ndarray,
+    *,
+    random_runs: int,
+    rng: Optional[np.random.Generator] = None,
+) -> np.ndarray:
+    """Apply uncertainty month-by-month to a ``(month, y, x)`` residues cube.
+
+    Only land-use pixels are perturbed; all other pixels keep their original
+    values. Exact zeros in the monthly baseline are preserved to avoid
+    introducing artefacts in sparse residue schedules.
+    """
+
+    baseline = np.asarray(monthly_residues, dtype="float32")
+    if baseline.ndim != 3:
+        raise ValueError("monthly_residues must have shape (month, y, x)")
+
+    lu_mask = np.asarray(lu_mask, dtype=bool)
+    if lu_mask.ndim != 2:
+        raise ValueError("lu_mask must have shape (y, x)")
+    if baseline.shape[1:] != lu_mask.shape:
+        raise ValueError("monthly_residues spatial shape must match lu_mask")
+
+    randomized = baseline.copy()
+
+    for month_idx in range(baseline.shape[0]):
+        month_result = _apply_uncertainty_to_yields(
+            result=baseline[month_idx],
+            fao_avg_yields_array=fao_avg_yields_array,
+            fao_sd_yields_array=fao_sd_yields_array,
+            lu_mask=lu_mask,
+            random_runs=random_runs,
+            rng=rng,
+        )
+        randomized[month_idx, lu_mask] = month_result[lu_mask]
+        randomized[month_idx, baseline[month_idx] == 0] = 0.0
+
+    return randomized.astype("float32", copy=False)
+
+
 def _read_cropland_raster(
     croplu_grid_raster: str,
 ) -> tuple[dict, np.ndarray, Affine, CRS, int, int, np.ndarray]:

--- a/tests/test_cropcalcs_yield.py
+++ b/tests/test_cropcalcs_yield.py
@@ -246,3 +246,25 @@ def test_pre_filter_local_zscore_runtime_sanity():
     elapsed = time.perf_counter() - t0
 
     assert elapsed < 5.0
+
+
+def test_apply_uncertainty_to_monthly_residues_preserves_sparse_zero_months():
+    monthly = np.zeros((12, 2, 2), dtype="float32")
+    monthly[2] = np.array([[1.0, 0.0], [2.0, 0.0]], dtype="float32")
+    monthly[7] = np.array([[0.5, 0.0], [1.5, 0.0]], dtype="float32")
+
+    lu_mask = np.array([[True, False], [True, False]])
+    fao_avg = np.array([[3.0, 0.0], [4.0, 0.0]], dtype="float32")
+    fao_sd = np.array([[0.3, 0.0], [0.4, 0.0]], dtype="float32")
+
+    randomized = cropcalcs._apply_uncertainty_to_monthly_residues(
+        monthly_residues=monthly,
+        fao_avg_yields_array=fao_avg,
+        fao_sd_yields_array=fao_sd,
+        lu_mask=lu_mask,
+        random_runs=20,
+        rng=np.random.default_rng(0),
+    )
+
+    assert randomized.shape == monthly.shape
+    np.testing.assert_allclose(randomized[monthly == 0.0], 0.0, rtol=0.0, atol=0.0)


### PR DESCRIPTION
### Motivation
- Avoid applying `_apply_uncertainty_to_yields` directly to a 3D `(12, y, x)` residues cube because the function expects a 2D baseline and treating a 3D array could perturb masked/zero months incorrectly. 
- Ensure that stochastic perturbations only affect valid land-use pixels and that exact-zero months (sparse residue schedules) remain exactly zero.

### Description
- Added `cropcalcs._apply_uncertainty_to_monthly_residues(...)` which validates a `(month, y, x)` cube and a 2D `(y, x)` mask, iterates months, calls `_apply_uncertainty_to_yields(...)` per 2D slice, assigns only land-use pixels, and re-enforces exact zeros for baseline-zero months. (file: `src/sbtn_leaf/cropcalcs.py`)
- Replaced the year-end residue refresh call in `_raster_rothc_annual_results` to use the new helper instead of calling `_apply_uncertainty_to_yields` on a 3D array. (file: `src/sbtn_leaf/RothC_Raster.py`)
- Added a regression test `test_apply_uncertainty_to_monthly_residues_preserves_sparse_zero_months` that creates a sparse monthly cube and asserts that zero months remain exactly zero after uncertainty handling. (file: `tests/test_cropcalcs_yield.py`)

### Testing
- Ran the new regression test: `pytest -q tests/test_cropcalcs_yield.py::test_apply_uncertainty_to_monthly_residues_preserves_sparse_zero_months` which passed. 
- Attempted running the new test together with `tests/test_rothc_raster.py` (`pytest -q tests/test_cropcalcs_yield.py::test_apply_uncertainty_to_monthly_residues_preserves_sparse_zero_months tests/test_rothc_raster.py -q`) and observed multiple unrelated failures originating in existing `tests/test_rothc_raster.py` (these failures appear to be due to dataset/test-setup assumptions and are not caused by this refactor).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dfb1b10d483318aa0227f33cfaa61)