### PR TITLE
Add batch raster plotting helper to map_plotting

### DIFF
--- a/src/sbtn_leaf/__init__.py
+++ b/src/sbtn_leaf/__init__.py
@@ -78,6 +78,7 @@ surface area.  The curated groups are:
   - :func:`extract_coordinates_values_from_raster`
 * Plotting helpers (:mod:`sbtn_leaf.map_plotting`)
   - :func:`plot_raster_on_world_extremes_cutoff`
+  - :func:`plot_n_rasters_on_world_extremes_cutoff`
   - :func:`plot_da_on_world_extremes_cutoff`
   - :func:`plot_all_raster_bands`
   - :func:`plot_raster_on_world_no_min`
@@ -217,6 +218,7 @@ from .map_plotting import (
     plot_raster_data_histogram,
     plot_raster_histogram,
     plot_raster_on_world_extremes_cutoff,
+    plot_n_rasters_on_world_extremes_cutoff,
     plot_raster_on_world_no_min,
     plot_raster_over_gdf,
     plot_raster_over_gdf_showpolygonvalues,
@@ -345,6 +347,7 @@ _MAP_PLOTTING_EXPORTS = [
     "plot_raster_data_histogram",
     "plot_raster_histogram",
     "plot_raster_on_world_extremes_cutoff",
+    "plot_n_rasters_on_world_extremes_cutoff",
     "plot_raster_on_world_no_min",
     "plot_raster_over_gdf",
     "plot_raster_over_gdf_showpolygonvalues",

--- a/src/sbtn_leaf/map_plotting.py
+++ b/src/sbtn_leaf/map_plotting.py
@@ -632,6 +632,78 @@ def plot_da_on_world_extremes_cutoff(
     return result
 
 
+def plot_n_rasters_on_world_extremes_cutoff(
+    rasters: Sequence[Union[str, Path, xr.DataArray]],
+    titles: Optional[Sequence[str]] = None,
+    label_title: str = 'Raster Values',
+    raster_band: int = 1,
+    band: Optional[int] = None,
+    perc_cutoff: Optional[float] = 1,
+    p_min: Optional[float] = None,
+    p_max: Optional[float] = None,
+    quantiles: Optional[Union[int, Sequence[float]]] = None,
+    region: Optional[str] = None,
+    cmap: str = 'viridis',
+    divergence_center: Optional[float] = None,
+    n_categories: int = 20,
+    base_shp: Optional[gpd.GeoDataFrame] = None,
+    plt_show: bool = True,
+    min_val: Optional[float] = None,
+    max_val: Optional[float] = None,
+    eliminate_zeros: bool = False,
+    diverg0: Optional[bool] = None,
+    truncate_one_sided: bool = False,
+) -> Sequence[Tuple[plt.Figure, plt.Axes]]:
+    """Plot an arbitrary number of rasters with the same styling workflow.
+
+    This is a convenience wrapper around :func:`plot_raster_on_world_extremes_cutoff`
+    for batch plotting. It accepts either file paths or ``xarray.DataArray``
+    objects and creates one figure per raster.
+    """
+
+    rasters = list(rasters)
+    if not rasters:
+        raise ValueError("'rasters' must contain at least one item.")
+
+    if titles is None:
+        resolved_titles = [f"Raster {idx + 1}" for idx in range(len(rasters))]
+    else:
+        resolved_titles = list(titles)
+        if len(resolved_titles) != len(rasters):
+            raise ValueError("'titles' length must match the number of rasters.")
+
+    results = []
+    for raster, title in zip(rasters, resolved_titles):
+        fig_ax = plot_raster_on_world_extremes_cutoff(
+            raster=raster,
+            title=title,
+            label_title=label_title,
+            raster_band=raster_band,
+            band=band,
+            perc_cutoff=perc_cutoff,
+            p_min=p_min,
+            p_max=p_max,
+            quantiles=quantiles,
+            region=region,
+            cmap=cmap,
+            divergence_center=divergence_center,
+            n_categories=n_categories,
+            base_shp=base_shp,
+            plt_show=False,
+            min_val=min_val,
+            max_val=max_val,
+            eliminate_zeros=eliminate_zeros,
+            diverg0=diverg0,
+            truncate_one_sided=truncate_one_sided,
+        )
+        results.append(fig_ax)
+
+    if plt_show:
+        plt.show()
+
+    return results
+
+
 def plot_all_raster_bands(
     tif_path: str,
     title_prefix: str = "",

--- a/tests/test_map_plotting_plots.py
+++ b/tests/test_map_plotting_plots.py
@@ -11,6 +11,7 @@ from sbtn_leaf.map_plotting import (
     _prepare_raster_plot_input,
     plot_raster_on_world_extremes_cutoff,
     plot_da_on_world_extremes_cutoff,
+    plot_n_rasters_on_world_extremes_cutoff,
 )
 
 
@@ -144,4 +145,34 @@ def test_plot_raster_divergence_guard(tmp_path):
             base_shp=gpd.GeoDataFrame(),
             divergence_center=0,
             diverg0=True,
+        )
+
+
+def test_plot_n_rasters_returns_figures(tmp_path):
+    raster_path, _, _ = _create_test_raster(tmp_path)
+
+    outputs = plot_n_rasters_on_world_extremes_cutoff(
+        [raster_path, raster_path],
+        titles=["A", "B"],
+        perc_cutoff=0,
+        base_shp=gpd.GeoDataFrame(),
+        plt_show=False,
+    )
+
+    assert len(outputs) == 2
+    for fig, ax in outputs:
+        assert fig is not None and ax is not None
+        plt.close(fig)
+
+
+def test_plot_n_rasters_title_length_guard(tmp_path):
+    raster_path, _, _ = _create_test_raster(tmp_path)
+
+    with pytest.raises(ValueError):
+        plot_n_rasters_on_world_extremes_cutoff(
+            [raster_path, raster_path],
+            titles=["Only one"],
+            perc_cutoff=0,
+            base_shp=gpd.GeoDataFrame(),
+            plt_show=False,
         )


### PR DESCRIPTION
## Summary
- added `plot_n_rasters_on_world_extremes_cutoff` to `src/sbtn_leaf/map_plotting.py`
- the new helper accepts a sequence of raster paths/DataArrays and applies the same plotting behavior as `plot_raster_on_world_extremes_cutoff`
- supports optional per-raster titles with validation and sensible defaults (`Raster 1`, `Raster 2`, ...)
- returns figure/axis tuples for each raster and supports deferred display via `plt_show=False`

## API surface updates
- exported `plot_n_rasters_on_world_extremes_cutoff` from `src/sbtn_leaf/__init__.py`
- updated plotting helper docs in the package module docstring

## Tests
- extended `tests/test_map_plotting_plots.py` with:
  - `test_plot_n_rasters_returns_figures`
  - `test_plot_n_rasters_title_length_guard`

## Notes
- no runtime tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f4622dcc4833185f3e8f111c11cc1)