### PR TITLE
Add resumable checkpointing and append-safe GeoPackage writes to build_cfs_gpkg_from_rasters

### DIFF
--- a/src/sbtn_leaf/map_calculations.py
+++ b/src/sbtn_leaf/map_calculations.py
@@ -14,6 +14,7 @@ from rasterio.mask import mask
 from rasterio.windows import Window
 import rioxarray
 import tempfile
+import json
 from contextlib import nullcontext
 from typing import Optional, Callable, Iterable, Tuple, Dict, List, Union, Sequence
 from shapely.geometry import box
@@ -25,7 +26,7 @@ import xarray as xr
 
 import os
 
-from pyogrio import write_dataframe as write_df
+from pyogrio import write_dataframe as write_df, list_layers as ogr_list_layers, read_dataframe as read_df
 gpd.options.io_engine = "pyogrio"  # To be able to write gpckg's
 
 
@@ -854,6 +855,9 @@ def build_cfs_gpkg_from_rasters(
     promote_to_multi: bool = True,   # avoid Polygon/MultiPolygon mismatches
     add_source_file_name: bool = True,     # add _source_file column
     run_test: bool = False,          # process only first 5 rasters
+    resume: bool = True,
+    checkpoint_path: Optional[str] = None,
+    fail_fast: bool = True,
     logger: Optional[logging.Logger] = build_logger,  # pass a logger or None
     write_gpkg: bool = True,         # optionally skip GeoPackage output entirely
 ) -> Tuple[Optional[str], pd.DataFrame]:
@@ -870,13 +874,55 @@ def build_cfs_gpkg_from_rasters(
     calc_kwargs = dict(calc_kwargs or {})
     calc_kwargs.setdefault("suppress_logging", True)
     output_string = (output_folder + gpckg_name ) if gpckg_name is not None else (output_folder + cf_name + "_" + area_type)
+    gpckg_path: Optional[str] = None
     if write_gpkg:
         gpckg_path = output_string + ".gpkg"
     csv_path = output_string + ".csv"
+    checkpoint_path = checkpoint_path or (output_string + ".checkpoint.json")
 
-    # Reset gpkg if requested
-    if write_gpkg and reset_gpkg and gpckg_path and os.path.exists(gpckg_path):
+    checkpoint_data: Dict[str, Union[List[str], Dict[str, str], str, int]] = {
+        "processed_files": [],
+        "failed_files": {},
+        "last_successful_file": None,
+    }
+
+    if resume and os.path.exists(checkpoint_path):
+        with open(checkpoint_path, "r", encoding="utf-8") as checkpoint_file:
+            loaded = json.load(checkpoint_file)
+        checkpoint_data["processed_files"] = list(loaded.get("processed_files", []))
+        checkpoint_data["failed_files"] = dict(loaded.get("failed_files", {}))
+        checkpoint_data["last_successful_file"] = loaded.get("last_successful_file")
+
+    processed_files = set(checkpoint_data.get("processed_files", []))
+    failed_files: Dict[str, str] = dict(checkpoint_data.get("failed_files", {}))
+
+    def _save_checkpoint() -> None:
+        checkpoint_data["processed_files"] = sorted(processed_files)
+        checkpoint_data["failed_files"] = failed_files
+        checkpoint_data["last_successful_file"] = checkpoint_data.get("last_successful_file")
+        checkpoint_data["remaining_files"] = len(file_list)
+        tmp_path = f"{checkpoint_path}.tmp"
+        with open(tmp_path, "w", encoding="utf-8") as checkpoint_file:
+            json.dump(checkpoint_data, checkpoint_file, indent=2)
+        os.replace(tmp_path, checkpoint_path)
+        if logger is not None:
+            logger.info("Checkpoint saved at %s", checkpoint_path)
+
+    # Reset gpkg/csv outputs if requested and no resumable checkpoint state is present
+    if (
+        write_gpkg
+        and reset_gpkg
+        and gpckg_path
+        and os.path.exists(gpckg_path)
+        and not (resume and processed_files)
+    ):
         os.remove(gpckg_path)
+
+    if reset_gpkg and os.path.exists(csv_path) and not (resume and processed_files):
+        os.remove(csv_path)
+
+    if reset_gpkg and resume and processed_files and logger is not None:
+        logger.info("Resume enabled with existing checkpoint; preserving existing outputs.")
 
     # Ensure master has needed columns & unique keys
     if master_key not in master_gdf.columns:
@@ -902,6 +948,18 @@ def build_cfs_gpkg_from_rasters(
         and (not input_raster_key_startswith or file.startswith(input_raster_key_startswith))
     ]
 
+    if resume and processed_files:
+        remaining_files = []
+        for file in file_list:
+            if file in processed_files:
+                if logger is not None:
+                    logger.info("Skipping already processed raster %s", file)
+                continue
+            remaining_files.append(file)
+        file_list = remaining_files
+        if logger is not None:
+            logger.info("Resuming from %s remaining rasters ...", len(file_list))
+
     progress_iter = tqdm(
         file_list,
         desc=f"Processing rasters ({layer_name})",
@@ -912,8 +970,16 @@ def build_cfs_gpkg_from_rasters(
 
     logging_context = logging_redirect_tqdm() if logger is not None else nullcontext()
 
+    # Discover existing GeoPackage layers once (used for append-safe behavior)
+    existing_layers: set[str] = set()
+    if write_gpkg and gpckg_path and os.path.exists(gpckg_path):
+        try:
+            existing_layers = {row[0] for row in ogr_list_layers(gpckg_path)}
+        except Exception:
+            existing_layers = set()
+
     # Prepare GeoPackage layer bookkeeping
-    attribute_first_write = True
+    attribute_first_write = not (write_gpkg and gpckg_path and (not reset_gpkg) and (layer_name in existing_layers))
     schema_cols: Optional[List[str]] = None
     total_rows = 0
 
@@ -927,7 +993,7 @@ def build_cfs_gpkg_from_rasters(
         drop_cols = [ 'STATUS', 'DISP_AREA', 'ADM0_CODE', 'STR0_YEAR', 'EXP0_YEAR', 'SHAPE_LENG', 'SHAPE_AREA']
     else:  #subcountry
         drop_cols = ['STR1_YEAR', 'EXP1_YEAR', 'STATUS', 'DISP_AREA', 'ADM0_CODE',  'SHAPE_LENG', "SHAPE_AREA"]
-    master_gdf = master_gdf.drop(columns=drop_cols)
+    master_gdf = master_gdf.drop(columns=drop_cols, errors="ignore")
 
     # Ensure master_gdf is in an equal-area CRS (avoid referencing undefined raster/resampling variables)    
     # Guard against missing attribute 'is_geographic' on unexpected CRS objects
@@ -940,15 +1006,19 @@ def build_cfs_gpkg_from_rasters(
 
     # Persist master geometry once (recommendation #1)
     if write_gpkg:
-        write_df(
-            master_gdf,
-            gpckg_path,
-            layer="geometry_layer",
-            driver="GPKG",
-            append=False,
-            promote_to_multi=promote_to_multi,
-            layer_options={"GEOMETRY_NAME": "geom", "SPATIAL_INDEX": "NO"}
-        )
+        should_write_geometry = reset_gpkg or ("geometry_layer" not in existing_layers)
+        if should_write_geometry:
+            write_df(
+                master_gdf,
+                gpckg_path,
+                layer="geometry_layer",
+                driver="GPKG",
+                append=False,
+                promote_to_multi=promote_to_multi,
+                layer_options={"GEOMETRY_NAME": "geom", "SPATIAL_INDEX": "NO"}
+            )
+        elif logger is not None:
+            logger.info("reset_gpkg=False and geometry_layer exists; preserving existing geometry layer.")
 
     # Base frame with master identifiers for later joins
     master_id_df = pd.DataFrame(master_gdf[master_key])
@@ -959,141 +1029,155 @@ def build_cfs_gpkg_from_rasters(
     # Iterates through files
     with logging_context:
         for file in progress_iter:
+            try:
+                raster_path = os.path.join(input_folder, file)
+                flow_name = os.path.splitext(file)[0]
+                if input_raster_key_startswith:
+                    flow_name = flow_name.replace(input_raster_key_startswith, "")
+                if input_raster_key_endswith:
+                    flow_name = flow_name.replace(input_raster_key_endswith, "")
 
-            raster_path = os.path.join(input_folder, file)
-            flow_name = os.path.splitext(file)[0]
-            if input_raster_key_startswith:
-                flow_name = flow_name.replace(input_raster_key_startswith, "")
-            if input_raster_key_endswith:
-                flow_name = flow_name.replace(input_raster_key_endswith, "")
+                if logger:
+                    logger.info(f"Calculating {cf_name} for {flow_name}...")
 
-            if logger:
-                logger.info(f"Calculating {cf_name} for {flow_name}...")
-
-            # Run calculator → (df, gdf)
-            df_flow, gdf_flow = calculate_area_weighted_cfs_from_raster_with_std_and_median_vOutliers(
-                raster_input_filepath=raster_path,
-                cf_name=cf_name,
-                cf_unit=cf_unit,
-                flow_name=flow_name,
-                area_type=area_type,
-                **calc_kwargs
-            )
-
-            # Check if the result is empty and thus skip
-            if df_flow is None or (isinstance(df_flow, pd.DataFrame) and df_flow.empty) or gdf_flow is None or getattr(gdf_flow, "empty", False):
-                if logger is not None:
-                    logger.info("No results for flow '%s' (file=%s). Skipping...", flow_name, file)
-                continue
-
-            # Align CRS
-            if gdf_flow.crs != master_gdf.crs:
-                if logger is not None:
-                    logger.info("Result gdf aligned with master_gdf")
-                gdf_flow = gdf_flow.set_crs(master_gdf.crs, allow_override=True)
-
-            # Ensure flow results include the expected join key
-            if master_key not in gdf_flow.columns:
-                raise KeyError(f"master_key '{master_key}' not found in result gdf. Available: {list(gdf_flow.columns)}")
-
-            # Merge onto master identifiers so all regions are represented
-            flow_values = master_id_df.merge(
-                df_flow[[result_key, "cf", "cf_median", "cf_std"]],
-                how="left",
-                left_on=master_key,
-                right_on=result_key,
-            )
-
-            if (result_key in flow_values.columns) and (master_key != result_key):
-                flow_values = flow_values.drop(columns=result_key)
-
-            flow_values.insert(1, "flow_name", flow_name)
-
-            for col in ("cf", "cf_median", "cf_std"):
-                if col in flow_values.columns:
-                    flow_values[col] = flow_values[col].astype("float32")
-
-            if add_source_file_name:
-                flow_values["_source_file"] = file
-
-            # Record metadata once per flow (recommendation #2)
-            metadata_entry = {
-                "flow_name": flow_name,
-                "impact_category": cf_name,
-                "unit": cf_unit,
-            }
-            if add_source_file_name:
-                metadata_entry["source_file"] = file
-            metadata_records.append(metadata_entry)
-
-            if write_gpkg:
-                # Initialize schema for attribute layer on first write
-                if attribute_first_write:
-                    base_cols = [master_key, "flow_name", "cf", "cf_median", "cf_std"]
-                    extras = [c for c in flow_values.columns if c not in base_cols]
-                    schema_cols = [c for c in base_cols + extras if c in flow_values.columns]
-                    append_flag = False
-                    attribute_first_write = False
-                else:
-                    append_flag = True
-
-                # Align columns to schema for stability across flows
-                if schema_cols is None:
-                    raise RuntimeError("GeoPackage schema not initialized before writing.")
-                for c in schema_cols:
-                    if c not in flow_values.columns:
-                        flow_values[c] = pd.NA
-                flow_values = flow_values[schema_cols]
-
-                write_df(
-                    flow_values,
-                    gpckg_path,
-                    layer=layer_name,
-                    driver="GPKG",
-                    append=append_flag,
+                # Run calculator → (df, gdf)
+                df_flow, gdf_flow = calculate_area_weighted_cfs_from_raster_with_std_and_median_vOutliers(
+                    raster_input_filepath=raster_path,
+                    cf_name=cf_name,
+                    cf_unit=cf_unit,
+                    flow_name=flow_name,
+                    area_type=area_type,
+                    **calc_kwargs
                 )
 
-            # Long-format table for CSV output (no constant columns)
-            mean_df = master_id_df.merge(
-                df_flow[[result_key, "cf"]],
-                how="left",
-                left_on=master_key,
-                right_on=result_key,
-            ).rename(columns={"cf": "value"})
-            mean_df["metric"] = "cf_mean"
+                # Check if the result is empty and thus skip
+                if df_flow is None or (isinstance(df_flow, pd.DataFrame) and df_flow.empty) or gdf_flow is None or getattr(gdf_flow, "empty", False):
+                    if logger is not None:
+                        logger.info("No results for flow '%s' (file=%s). Skipping...", flow_name, file)
+                    continue
 
-            median_df = master_id_df.merge(
-                df_flow[[result_key, "cf_median"]],
-                how="left",
-                left_on=master_key,
-                right_on=result_key,
-            ).rename(columns={"cf_median": "value"})
-            median_df["metric"] = "cf_median"
+                # Align CRS
+                if gdf_flow.crs != master_gdf.crs:
+                    if logger is not None:
+                        logger.info("Result gdf aligned with master_gdf")
+                    gdf_flow = gdf_flow.set_crs(master_gdf.crs, allow_override=True)
 
-            std_df = master_id_df.merge(
-                df_flow[[result_key, "cf_std"]],
-                how="left",
-                left_on=master_key,
-                right_on=result_key,
-            ).rename(columns={"cf_std": "value"})
-            std_df["metric"] = "cf_std"
+                # Ensure flow results include the expected join key
+                if master_key not in gdf_flow.columns:
+                    raise KeyError(f"master_key '{master_key}' not found in result gdf. Available: {list(gdf_flow.columns)}")
 
-            for frame in (mean_df, median_df, std_df):
+                # Merge onto master identifiers so all regions are represented
+                flow_values = master_id_df.merge(
+                    df_flow[[result_key, "cf", "cf_median", "cf_std"]],
+                    how="left",
+                    left_on=master_key,
+                    right_on=result_key,
+                )
+
                 if (result_key in flow_values.columns) and (master_key != result_key):
-                    frame = frame.drop(columns=result_key)
-                frame["flow_name"] = flow_name
-                long_result_frames.append(frame)
+                    flow_values = flow_values.drop(columns=result_key)
 
-            if write_gpkg:
-                total_rows += len(flow_values)
+                flow_values.insert(1, "flow_name", flow_name)
+
+                for col in ("cf", "cf_median", "cf_std"):
+                    if col in flow_values.columns:
+                        flow_values[col] = flow_values[col].astype("float32")
+
+                if add_source_file_name:
+                    flow_values["_source_file"] = file
+
+                # Record metadata once per flow (recommendation #2)
+                metadata_entry = {
+                    "flow_name": flow_name,
+                    "impact_category": cf_name,
+                    "unit": cf_unit,
+                }
+                if add_source_file_name:
+                    metadata_entry["source_file"] = file
+                metadata_records.append(metadata_entry)
+
+                if write_gpkg:
+                    # Initialize schema for attribute layer on first write
+                    if schema_cols is None:
+                        if (not attribute_first_write) and gpckg_path and os.path.exists(gpckg_path):
+                            try:
+                                existing_attr = read_df(gpckg_path, layer=layer_name, max_features=1, read_geometry=False)
+                                schema_cols = list(existing_attr.columns)
+                            except Exception:
+                                schema_cols = None
+                        if schema_cols is None:
+                            base_cols = [master_key, "flow_name", "cf", "cf_median", "cf_std"]
+                            extras = [c for c in flow_values.columns if c not in base_cols]
+                            schema_cols = [c for c in base_cols + extras if c in flow_values.columns]
+
+                    append_flag = not attribute_first_write
+                    attribute_first_write = False
+
+                    # Align columns to schema for stability across flows
+                    if schema_cols is None:
+                        raise RuntimeError("GeoPackage schema not initialized before writing.")
+                    for c in schema_cols:
+                        if c not in flow_values.columns:
+                            flow_values[c] = pd.NA
+                    flow_values = flow_values[schema_cols]
+
+                    write_df(
+                        flow_values,
+                        gpckg_path,
+                        layer=layer_name,
+                        driver="GPKG",
+                        append=append_flag,
+                    )
+
+                # Long-format table for CSV output (no constant columns)
+                metrics_wide = master_id_df.merge(
+                    df_flow[[result_key, "cf", "cf_median", "cf_std"]],
+                    how="left",
+                    left_on=master_key,
+                    right_on=result_key,
+                )
+                if (result_key in metrics_wide.columns) and (master_key != result_key):
+                    metrics_wide = metrics_wide.drop(columns=result_key)
+
+                flow_long_df = metrics_wide.melt(
+                    id_vars=[master_key],
+                    value_vars=["cf", "cf_median", "cf_std"],
+                    var_name="metric",
+                    value_name="value",
+                )
+                flow_long_df["metric"] = flow_long_df["metric"].replace({"cf": "cf_mean"})
+                flow_long_df["flow_name"] = flow_name
+                flow_long_df = flow_long_df[[master_key, "flow_name", "metric", "value"]]
+
+                long_result_frames.append(flow_long_df)
+                csv_exists = os.path.exists(csv_path)
+                flow_long_df.to_csv(csv_path, mode="a", header=not csv_exists, index=False)
+
+                if write_gpkg:
+                    total_rows += len(flow_values)
+
+                processed_files.add(file)
+                failed_files.pop(file, None)
+                checkpoint_data["last_successful_file"] = file
+                _save_checkpoint()
+            except Exception as exc:
+                failed_files[file] = str(exc)
+                _save_checkpoint()
+                if logger is not None:
+                    logger.exception("Failed raster %s; progress preserved at %s", file, checkpoint_path)
+                if fail_fast:
+                    raise
+                continue
 
     if hasattr(progress_iter, "close"):
         progress_iter.close()
     elif hasattr(progress_iter, "update"):
         progress_iter.update(0)
 
-    # Combine long-format data and persist to CSV
-    if long_result_frames:
+    # Rebuild long-format data from CSV (source of truth for long runs)
+    if os.path.exists(csv_path):
+        results_df = pd.read_csv(csv_path)
+    elif long_result_frames:
         results_df = pd.concat(long_result_frames, ignore_index=True)
     else:
         results_df = pd.DataFrame(columns=[master_key, "flow_name", "metric", "value"])
@@ -1105,13 +1189,22 @@ def build_cfs_gpkg_from_rasters(
     elif area_type == "ecoregion":
         results_df = results_df.merge(master_gdf[['ECO_ID', 'ECO_NAME', 'BIOME_NUM', 'BIOME_NAME', 'REALM']], how="left", on="ECO_ID")
     
-    # Store results
-    results_df.to_csv(csv_path, index=False)
+    # Store results when nothing has been appended yet
+    if not os.path.exists(csv_path):
+        results_df.to_csv(csv_path, index=False)
 
     # Persist metadata table once (recommendation #2)
     if write_gpkg and metadata_records:
         metadata_df = pd.DataFrame(metadata_records).drop_duplicates(subset=["flow_name"], keep="last")
         metadata_layer = f"{layer_name}_metadata"
+        if gpckg_path and os.path.exists(gpckg_path):
+            try:
+                existing_metadata = read_df(gpckg_path, layer=metadata_layer, read_geometry=False)
+            except Exception:
+                existing_metadata = pd.DataFrame()
+            if not existing_metadata.empty:
+                metadata_df = pd.concat([existing_metadata, metadata_df], ignore_index=True)
+                metadata_df = metadata_df.drop_duplicates(subset=["flow_name"], keep="last")
         write_df(
             metadata_df,
             gpckg_path,

--- a/tests/test_map_calculations_resume.py
+++ b/tests/test_map_calculations_resume.py
@@ -1,0 +1,187 @@
+"""Tests for checkpointed/resumable raster-to-tabular builds."""
+
+from pathlib import Path
+
+import geopandas as gpd
+import pandas as pd
+import pytest
+from shapely.geometry import Point
+
+from sbtn_leaf import map_calculations as mc
+
+
+def _build_master_gdf() -> gpd.GeoDataFrame:
+    rows = [
+        {
+            "ECO_ID": 1,
+            "ECO_NAME": "Region A",
+            "BIOME_NUM": 10,
+            "BIOME_NAME": "Biome",
+            "REALM": "Realm",
+            "NNH": "",
+            "SHAPE_LENG": 0.0,
+            "SHAPE_AREA": 0.0,
+            "NNH_NAME": "",
+            "COLOR": "",
+            "COLOR_BIO": "",
+            "COLOR_NNH": "",
+            "LICENSE": "",
+            "geometry": Point(0, 0),
+        },
+        {
+            "ECO_ID": 2,
+            "ECO_NAME": "Region B",
+            "BIOME_NUM": 10,
+            "BIOME_NAME": "Biome",
+            "REALM": "Realm",
+            "NNH": "",
+            "SHAPE_LENG": 0.0,
+            "SHAPE_AREA": 0.0,
+            "NNH_NAME": "",
+            "COLOR": "",
+            "COLOR_BIO": "",
+            "COLOR_NNH": "",
+            "LICENSE": "",
+            "geometry": Point(1, 1),
+        },
+    ]
+    return gpd.GeoDataFrame(rows, geometry="geometry", crs="EPSG:6933")
+
+
+def _flow_output(flow_name: str):
+    df = pd.DataFrame(
+        {
+            "ECO_ID": [1, 2],
+            "cf": [1.0, 2.0],
+            "cf_median": [1.1, 2.1],
+            "cf_std": [0.1, 0.2],
+        }
+    )
+    gdf = gpd.GeoDataFrame({"ECO_ID": [1, 2], "geometry": [Point(0, 0), Point(1, 1)]}, geometry="geometry", crs="EPSG:6933")
+    return df, gdf
+
+
+def test_build_cfs_gpkg_resume_checkpoint(tmp_path, monkeypatch):
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+    input_dir.mkdir()
+    output_dir.mkdir()
+
+    for name in ("flow_a.tif", "flow_b.tif", "flow_c.tif"):
+        (input_dir / name).write_text("placeholder")
+
+    state = {"flow_b_failures": 0, "calls": []}
+
+    def flaky_calc(*, raster_input_filepath, flow_name, **kwargs):
+        state["calls"].append(Path(raster_input_filepath).name)
+        if flow_name == "flow_b" and state["flow_b_failures"] == 0:
+            state["flow_b_failures"] += 1
+            raise RuntimeError("simulated failure")
+        return _flow_output(flow_name)
+
+    monkeypatch.setattr(mc, "calculate_area_weighted_cfs_from_raster_with_std_and_median_vOutliers", flaky_calc)
+
+    with pytest.raises(RuntimeError):
+        mc.build_cfs_gpkg_from_rasters(
+            input_folder=str(input_dir),
+            output_folder=str(output_dir) + "/",
+            layer_name="test_layer",
+            master_gdf=_build_master_gdf(),
+            master_key="ECO_ID",
+            result_key="ECO_ID",
+            cf_name="impact",
+            cf_unit="unit",
+            area_type="ecoregion",
+            write_gpkg=False,
+            fail_fast=True,
+            resume=True,
+        )
+
+    csv_path = output_dir / "impact_ecoregion.csv"
+    checkpoint_path = output_dir / "impact_ecoregion.checkpoint.json"
+    assert csv_path.exists()
+    assert checkpoint_path.exists()
+
+    first_run = pd.read_csv(csv_path)
+    assert set(first_run["flow_name"].unique()) == {"flow_a"}
+
+    state["calls"] = []
+
+    mc.build_cfs_gpkg_from_rasters(
+        input_folder=str(input_dir),
+        output_folder=str(output_dir) + "/",
+        layer_name="test_layer",
+        master_gdf=_build_master_gdf(),
+        master_key="ECO_ID",
+        result_key="ECO_ID",
+        cf_name="impact",
+        cf_unit="unit",
+        area_type="ecoregion",
+        write_gpkg=False,
+        fail_fast=True,
+        resume=True,
+    )
+
+    assert "flow_a.tif" not in state["calls"]
+    assert state["calls"] == ["flow_b.tif", "flow_c.tif"]
+
+    rerun = pd.read_csv(csv_path)
+    assert set(rerun["flow_name"].unique()) == {"flow_a", "flow_b", "flow_c"}
+
+
+def test_build_cfs_gpkg_reset_false_preserves_existing_layers(tmp_path, monkeypatch):
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+    input_dir.mkdir()
+    output_dir.mkdir()
+
+    for name in ("flow_a.tif", "flow_b.tif"):
+        (input_dir / name).write_text("placeholder")
+
+    gpkg_path = output_dir / "impact_ecoregion.gpkg"
+    gpkg_path.write_text("placeholder")
+
+    def stable_calc(*, flow_name, **kwargs):
+        return _flow_output(flow_name)
+
+    calls = []
+
+    def fake_write_df(df, path, layer, driver, append, **kwargs):
+        calls.append({"layer": layer, "append": append, "cols": list(df.columns)})
+
+    def fake_list_layers(path):
+        return [("geometry_layer", "Point"), ("test_layer", "None"), ("test_layer_metadata", "None")]
+
+    def fake_read_df(path, layer=None, max_features=None, read_geometry=None, **kwargs):
+        if layer == "test_layer":
+            return pd.DataFrame(columns=["ECO_ID", "flow_name", "cf", "cf_median", "cf_std", "_source_file"])
+        if layer == "test_layer_metadata":
+            return pd.DataFrame(columns=["flow_name", "impact_category", "unit", "source_file"])
+        return pd.DataFrame()
+
+    monkeypatch.setattr(mc, "calculate_area_weighted_cfs_from_raster_with_std_and_median_vOutliers", stable_calc)
+    monkeypatch.setattr(mc, "write_df", fake_write_df)
+    monkeypatch.setattr(mc, "ogr_list_layers", fake_list_layers)
+    monkeypatch.setattr(mc, "read_df", fake_read_df)
+
+    mc.build_cfs_gpkg_from_rasters(
+        input_folder=str(input_dir),
+        output_folder=str(output_dir) + "/",
+        layer_name="test_layer",
+        master_gdf=_build_master_gdf(),
+        master_key="ECO_ID",
+        result_key="ECO_ID",
+        cf_name="impact",
+        cf_unit="unit",
+        area_type="ecoregion",
+        write_gpkg=True,
+        reset_gpkg=False,
+        resume=False,
+    )
+
+    geometry_writes = [c for c in calls if c["layer"] == "geometry_layer"]
+    assert not geometry_writes, "geometry_layer should not be overwritten when reset_gpkg=False"
+
+    value_writes = [c for c in calls if c["layer"] == "test_layer"]
+    assert value_writes
+    assert value_writes[0]["append"] is True


### PR DESCRIPTION
### Motivation

- Enable long-running raster-to-attribute builds to be interruptible and resumable without re-processing completed rasters.
- Avoid overwriting existing GeoPackage geometry/attribute layers when appending new flows and provide safer append behavior for incremental runs.

### Description

- Added checkpointing and resume support to `build_cfs_gpkg_from_rasters` with new parameters `resume`, `checkpoint_path`, and `fail_fast`, and persisted checkpoint state as JSON to track `processed_files`, `failed_files`, and `last_successful_file`.
- Implemented incremental CSV output for long-format results and logic to rebuild `results_df` from the CSV when present, plus atomic checkpoint writes via a `.tmp` file and `os.replace`.
- Made GeoPackage writes append-safe by discovering existing layers with `pyogrio.list_layers`, conditional writing of the persistent `geometry_layer`, and schema discovery for attribute layer writes using `pyogrio.read_dataframe` when available.
- Miscellaneous robustness fixes: added `json` import, safer `drop(columns=..., errors="ignore")`, explicit CRS checks/conversions, typed local bookkeeping variables, and improved logging around resume and failures.

### Testing

- Added `tests/test_map_calculations_resume.py` containing `test_build_cfs_gpkg_resume_checkpoint` and `test_build_cfs_gpkg_reset_false_preserves_existing_layers` that exercise checkpoint resume behavior and append-preservation of existing GeoPackage layers.
- Ran the new tests with `pytest tests/test_map_calculations_resume.py` and they passed locally (both tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7124bb4808331980399df2e0b0e10)