### PR TITLE
Add leaf_path() helper function and fix LEAFs_dir() docstring

### DIFF
--- a/src/sbtn_leaf/paths.py
+++ b/src/sbtn_leaf/paths.py
@@ -58,9 +58,10 @@ def examples_dir() -> Path:
     return _EXAMPLES_DIR
 
 def LEAFs_dir() -> Path:
-    """Return the absolute path to the ``examples`` directory."""
+    """Return the absolute path to the ``LEAFs`` directory."""
 
     return _LEAFS_DIR
+
 
 @overload
 def data_path(*parts: PathLike) -> Path:
@@ -90,6 +91,36 @@ def data_path(*parts: PathLike | Iterable[PathLike]) -> Path:
         parts_iterable = parts
 
     return _DATA_DIR.joinpath(*map(Path, parts_iterable))
+
+
+@overload
+def leaf_path(*parts: PathLike) -> Path:
+    ...
+
+
+@overload
+def leaf_path(parts: Iterable[PathLike]) -> Path:
+    ...
+
+
+def leaf_path(*parts: PathLike | Iterable[PathLike]) -> Path:
+    """Return a path inside the repository ``LEAFs`` directory.
+
+    Parameters
+    ----------
+    parts:
+        Optional path segments that will be joined beneath ``LEAFs``.  The
+        helper accepts either variadic positional arguments or a single
+        iterable for convenience.  ``Path`` objects are returned to maximise
+        compatibility with consumers that accept ``os.PathLike`` values.
+    """
+
+    if len(parts) == 1 and isinstance(parts[0], Iterable) and not isinstance(parts[0], (str, bytes, Path)):
+        parts_iterable = parts[0]
+    else:
+        parts_iterable = parts
+
+    return _LEAFS_DIR.joinpath(*map(Path, parts_iterable))
 
 
 def project_path(*parts: PathLike) -> Path:


### PR DESCRIPTION
## Summary
This PR adds a new `leaf_path()` helper function to provide convenient path resolution within the repository's `LEAFs` directory, mirroring the existing `data_path()` function. It also fixes an incorrect docstring in the `LEAFs_dir()` function.

## Key Changes
- **Fixed docstring**: Corrected `LEAFs_dir()` docstring from "examples directory" to "LEAFs directory"
- **Added `leaf_path()` function**: New helper function that constructs paths within the `LEAFs` directory with the same flexible API as `data_path()`
  - Supports both variadic positional arguments and a single iterable of path segments
  - Includes proper type hints with `@overload` decorators for better IDE support
  - Returns `Path` objects for `os.PathLike` compatibility
  - Includes comprehensive docstring with parameter documentation

## Implementation Details
The `leaf_path()` function follows the same pattern as the existing `data_path()` function:
- Accepts either multiple path segments as positional arguments or a single iterable
- Intelligently detects whether the first argument is an iterable (excluding strings, bytes, and Path objects)
- Joins all path segments beneath the `_LEAFS_DIR` base directory
- Maintains consistency with the codebase's path handling conventions

https://claude.ai/code/session_01BqBjEwJzvq83iqexMohgrc